### PR TITLE
Print totals in quiet mode, if specified

### DIFF
--- a/jpegoptim.c
+++ b/jpegoptim.c
@@ -891,7 +891,7 @@ int main(int argc, char **argv)
   } while (++i<argc && !stdin_mode);
 
 
-  if (totals_mode && !quiet_mode)
+  if (totals_mode)
     fprintf(LOG_FH,"Average ""compression"" (%ld files): %0.2f%% (%0.0fk)\n",
 	    average_count, average_rate/average_count, total_save);
   jpeg_destroy_decompress(&dinfo);


### PR DESCRIPTION
As totals is an explicitly specified parameter, it should also be considered in quiet mode. If a user does not want totals, the parameter can just be left out. Otherwise it is not possible to get totals but suppress output for each file.
As the default for totals is 0, the current behavior if called without -t should not change.